### PR TITLE
Set  "applicationUrl" to https in launchsettings.json

### DIFF
--- a/src/BackendAccountService.Api/Properties/launchSettings.json
+++ b/src/BackendAccountService.Api/Properties/launchSettings.json
@@ -14,7 +14,7 @@
       "dotnetRunMessages": true,
       "launchBrowser": true,
       "launchUrl": "swagger",
-      "applicationUrl": "http://localhost:5000",
+      "applicationUrl": "https://localhost:5000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/SMAL-270

Set  "applicationUrl" to https in launchsettings.json BackendAccountService.Api profile. 
This had caused problems when trying to run the services locally, and is easily missed.
Other services configuration expected the service to run on Https rather than Http.