### PR TITLE
fix(accounts): use user id in re-invite validation messages (AMCR-124)

### DIFF
--- a/src/BackendAccountService.Api.UnitTests/Controllers/AccountsManagementControllerTests.cs
+++ b/src/BackendAccountService.Api.UnitTests/Controllers/AccountsManagementControllerTests.cs
@@ -160,7 +160,7 @@ public class AccountsManagementControllerTests
         validationProblemDetails.Errors.Count.Should().Be(1);
         validationProblemDetails.Errors.FirstOrDefault().Key.Should().Be("Email");
         validationProblemDetails.Errors.FirstOrDefault().Value.First().Should()
-            .Be("Invited user 'test@abc.com' is enrolled already.");
+            .Be("Invited user id '11111111-1111-1111-1111-111111111111' is enrolled already.");
     }
 
     [TestMethod]
@@ -195,7 +195,7 @@ public class AccountsManagementControllerTests
         validationProblemDetails.Errors.Count.Should().Be(1);
         validationProblemDetails.Errors.FirstOrDefault().Key.Should().Be("Email");
         validationProblemDetails.Errors.FirstOrDefault().Value.First().Should()
-            .Be("Invited user 'test@abc.com' doesn't belong to the same organisation.");
+            .Be("Invited user id '11111111-1111-1111-1111-111111111111' doesn't belong to the same organisation.");
     }
 
     [TestMethod]
@@ -279,6 +279,7 @@ public class AccountsManagementControllerTests
             InvitedUser = new()
             {
                 Email = "test@abc.com",
+                UserId = new Guid("11111111-1111-1111-1111-111111111111"),
                 OrganisationId = _existingOrgId,
                 PersonRoleId = 2,
                 ServiceRoleId = 3

--- a/src/BackendAccountService.Api/Controllers/AccountsManagementController.cs
+++ b/src/BackendAccountService.Api/Controllers/AccountsManagementController.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using BackendAccountService.Api.Configuration;
+using BackendAccountService.Core.Helpers;
 using BackendAccountService.Core.Models.Request;
 using BackendAccountService.Core.Services;
 using BackendAccountService.Data.Entities;
@@ -91,12 +92,12 @@ public class AccountsManagementController : ApiControllerBase
             }
 
             ModelState.AddModelError(nameof(request.InvitedUser.Email),
-                $"Invited user '{request.InvitedUser.Email}' doesn't belong to the same organisation.");
+                $"Invited user id '{UserIdentifier.FromInvitedUser(request.InvitedUser)}' doesn't belong to the same organisation.");
         }
         else
         {
             ModelState.AddModelError(nameof(request.InvitedUser.Email),
-                $"Invited user '{request.InvitedUser.Email}' is enrolled already.");
+                $"Invited user id '{UserIdentifier.FromInvitedUser(request.InvitedUser)}' is enrolled already.");
         }
 
         return false;

--- a/src/BackendAccountService.Core.UnitTests/Services/AccountManagementServiceTests.cs
+++ b/src/BackendAccountService.Core.UnitTests/Services/AccountManagementServiceTests.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using BackendAccountService.Core.Helpers;
 using BackendAccountService.Core.Models.Request;
 using BackendAccountService.Core.Services;
 using BackendAccountService.Core.UnitTests.TestHelpers;
@@ -322,8 +323,11 @@ public class AccountManagementServiceTests
 
         var differentOrganisationId = new Guid("00000000-0000-0000-0000-000000000003");
 
-        //Act & Assert
-        await Assert.ThrowsExactlyAsync<ValidationException>(async () => await _sut.ReInviteUserAsync(new InvitedUser
+        var invitedDbUser = _accountContext.Users.Single(x => x.Email == initialInviteRequest.InvitedUser.Email);
+        var expectedUserId = UserIdentifier.FromUser(invitedDbUser);
+
+        var ex = await Assert.ThrowsExactlyAsync<ValidationException>(async () => await _sut.ReInviteUserAsync(
+            new InvitedUser
             {
                 Email = initialInviteRequest.InvitedUser.Email,
                 OrganisationId = differentOrganisationId,
@@ -333,5 +337,8 @@ public class AccountManagementServiceTests
             },
             initialInviteRequest.InvitingUser));
 
+        ex.Message.Should().Be(
+            $"Invited user id '{expectedUserId}' doesn't belong to the same organisation.");
+        ex.Message.Should().NotContain(initialInviteRequest.InvitedUser.Email);
     }
 }

--- a/src/BackendAccountService.Core/Helpers/UserIdentifier.cs
+++ b/src/BackendAccountService.Core/Helpers/UserIdentifier.cs
@@ -1,0 +1,28 @@
+using System.Globalization;
+using BackendAccountService.Core.Models.Request;
+using BackendAccountService.Data.Entities;
+
+namespace BackendAccountService.Core.Helpers;
+
+public static class UserIdentifier
+{
+    public static string FromUser(User user)
+    {
+        if (user.UserId is { } uid && uid != Guid.Empty)
+        {
+            return uid.ToString();
+        }
+
+        return user.Id.ToString(CultureInfo.InvariantCulture);
+    }
+
+    public static string FromInvitedUser(InvitedUser invitedUser)
+    {
+        if (invitedUser.UserId is { } uid && uid != Guid.Empty)
+        {
+            return uid.ToString();
+        }
+
+        return "unspecified-user-id";
+    }
+}

--- a/src/BackendAccountService.Core/Services/AccountManagementService.cs
+++ b/src/BackendAccountService.Core/Services/AccountManagementService.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using BackendAccountService.Core.Helpers;
 using BackendAccountService.Core.Models.Request;
 using BackendAccountService.Data.Entities;
 using BackendAccountService.Data.Infrastructure;
@@ -93,7 +94,8 @@ public class AccountManagementService : IAccountManagementService
 
         if (invitedUserOrganisationConnection is null)
         {
-            throw new ValidationException($"Invited user '{invitedUser.Email}' doesn't belong to the same organisation.");
+            throw new ValidationException(
+                $"Invited user id '{UserIdentifier.FromUser(invited)}' doesn't belong to the same organisation.");
         }
 
         invitedUserOrganisationConnection.PersonRoleId = invitedUser.PersonRoleId;


### PR DESCRIPTION
## Summary
Use stable user identifiers instead of email in re-invite validation errors (API model state and core \ValidationException\).

## Jira
- https://eaflood.atlassian.net/browse/AMCR-124

## Testing
- \dotnet test\ on \BackendAccountService.Api.UnitTests\ and \BackendAccountService.Core.UnitTests\ (pass).
- Full solution includes integration tests that require environment; not run green locally.

---
_Fixes https://eaflood.atlassian.net/browse/AMCR-124_

Made with [Cursor](https://cursor.com)