### PR TITLE
AMCR-131: Production Error - Error logs showing PII

### DIFF
--- a/pipelines/azure-pipelines.yml
+++ b/pipelines/azure-pipelines.yml
@@ -45,9 +45,10 @@ variables:
 resources:
   repositories:
     - repository: CommonTemplates
-      name: RWD-CPR-EPR4P-ADO/epr-webapps-code-deploy-templates
-      type: git
+      name: defra/epr-webapps-code-deploy-templates
+      type: github
       ref: main
+      endpoint: DEFRA
 
 extends:
   template: epr-build-pipeline.yaml@CommonTemplates

--- a/pipelines/deployment-pipeline.yaml
+++ b/pipelines/deployment-pipeline.yaml
@@ -77,8 +77,9 @@ variables:
 resources:
   repositories:
     - repository: CommonTemplates
-      name: RWD-CPR-EPR4P-ADO/epr-webapps-code-deploy-templates
-      type: git
+      name: defra/epr-webapps-code-deploy-templates
+      type: github
+      endpoint: defra
       ref: main
 
     # The repo will be reference the repo by a release tag (if the imageTag parameter contains 'release') otherwise it will pull down the main branch.

--- a/pipelines/release-notes/README.md
+++ b/pipelines/release-notes/README.md
@@ -1,0 +1,59 @@
+# Automated release note generation scripts
+
+[`generate-release-notes.sh`](generate-release-notes.sh) uses [git cliff](https://git-cliff.org/) to parse commit logs and generate release notes from them.
+
+You'll need to have the git-cliff binary on your path to generate the release notes.
+
+If git commits follow "[conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)" conventions with some tweaks we can more easily answer the question of "what is going out" in any given release.
+
+Supported conventions:
+
+1. Prefixes for `feat:`, `fix:` etc to group changes into areas
+2. Finding jira ticket urls in any commit and including in release notes
+3. Adding a `Fixes <jira_url>` to differentiate between work towards a ticket and a completed feature
+
+See [`cliff.toml`](cliff.toml) for current configuration and supported commit message parsing.
+
+## Usage
+
+Release notes for latest release tag:
+
+```shell
+./pipelines/release-notes/generate-release-notes.sh
+```
+
+Release notes since latest release tag:
+
+```shell
+./pipelines/release-notes/generate-release-notes.sh --preview
+```
+
+## Example output
+
+```md
+$ ./pipelines/release-notes/generate-release-notes.sh --preview
+
+# Release notes for epr-backend-account-microservice
+
+Unreleased changes since [v1.0.0](https://github.com/DEFRA/epr-backend-account-microservice/releases/tag/v1.0.0)
+
+- Diff & commits: [v1.0.0...feature-branch](https://github.com/DEFRA/epr-backend-account-microservice/compare/v1.0.0...feature-branch)
+- Permalink: [abc1234...def5678](https://github.com/DEFRA/epr-backend-account-microservice/compare/abc1234...def5678)
+
+## 🚀 Features
+
+- Some feature from a semantic commit `feat: Some feature...` https://eaflood.atlassian.net/browse/AAA-0001
+
+## 📋 Additional changes
+
+- Other changes with ticket info in the commit  https://eaflood.atlassian.net/browse/AAA-0002
+
+
+## ✅ Completed Tickets
+
+- https://eaflood.atlassian.net/browse/AAA-0003
+
+## 🎫 Related Tickets
+
+- https://eaflood.atlassian.net/browse/AAA-0004
+```

--- a/pipelines/release-notes/cliff.toml
+++ b/pipelines/release-notes/cliff.toml
@@ -1,0 +1,150 @@
+# git-cliff ~ configuration file
+# https://git-cliff.org/docs/configuration
+
+
+[changelog]
+# A Tera template to be rendered for each release in the changelog.
+# See https://keats.github.io/tera/docs/#introduction
+body = """
+# Release notes for epr-backend-account-microservice
+
+{% if version %}\
+    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+    Unreleased changes since [{{ previous.version }}](https://github.com/DEFRA/epr-backend-account-microservice/releases/tag/{{ previous.version }})
+
+    - Diff & commits: [{{ previous.version }}...{{ get_env(name="CLIFF_CURRENT_REF", default="HEAD") }}](https://github.com/DEFRA/epr-backend-account-microservice/compare/{{ previous.version }}...{{ get_env(name="CLIFF_CURRENT_REF", default="HEAD") }})
+    - Permalink: [{{ get_env(name="CLIFF_PREVIOUS_SHA_SHORT", default="") }}...{{ get_env(name="CLIFF_CURRENT_SHA_SHORT", default="") }}](https://github.com/DEFRA/epr-backend-account-microservice/compare/{{ get_env(name="CLIFF_PREVIOUS_SHA", default="") }}...{{ get_env(name="CLIFF_CURRENT_SHA", default="") }})
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+    ## {{ group | striptags | trim | upper_first }}
+    {% for commit in commits | sort(attribute="message") %}
+        - {% if commit.scope %}*({{ commit.scope }})* {% endif %}\
+            {% if commit.breaking %}[**breaking**] {% endif %}\
+            {{ commit.message | split(pat="\n") | first | upper_first }}\
+            {% for link in commit.links %} {{ link.href }}{% endfor %}\
+    {% endfor %}
+{% endfor %}
+"""
+# Footer template rendered once at the end of the changelog.
+footer = """
+{% set completed_tickets = [] -%}
+{% set related_tickets = [] -%}
+{% for release in releases -%}
+    {% for commit in release.commits -%}
+        {% for link in commit.links -%}
+            {% if link.href is containing("eaflood.atlassian.net/browse/") -%}
+                {% set body_text = commit.body | default(value="") -%}
+                {% set msg_text = commit.message | default(value="") -%}
+                {% set full_text = msg_text ~ " " ~ body_text -%}
+                {% if full_text is containing("Fixes " ~ link.href) or full_text is containing("Closes " ~ link.href) -%}
+                    {% set_global completed_tickets = completed_tickets | concat(with=[link.href]) -%}
+                {% else -%}
+                    {% set_global related_tickets = related_tickets | concat(with=[link.href]) -%}
+                {% endif -%}
+            {% endif -%}
+        {% endfor -%}
+    {% endfor -%}
+{% endfor -%}
+{% set unique_completed = completed_tickets | unique | sort -%}
+{% set unique_related = related_tickets | unique | sort -%}
+{# Remove completed tickets from related list #}
+{% set filtered_related = [] -%}
+{% for url in unique_related -%}
+    {% if url not in unique_completed -%}
+        {% set_global filtered_related = filtered_related | concat(with=[url]) -%}
+    {% endif -%}
+{% endfor -%}
+{% if unique_completed | length > 0 %}
+
+## ✅ Completed Tickets
+
+{% for url in unique_completed -%}
+- {{ url }}
+{% endfor -%}
+{% endif -%}
+{% if filtered_related | length > 0 %}
+
+## 🎫 Related Tickets
+
+{% for url in filtered_related -%}
+- {{ url }}
+{% endfor -%}
+{% endif -%}
+"""
+# Remove leading and trailing whitespaces from the changelog's body.
+trim = true
+# Render body even when there are no releases to process.
+render_always = true
+# An array of regex based postprocessors to modify the changelog.
+postprocessors = [
+    # Replace the placeholder <REPO> with a URL.
+    #{ pattern = '<REPO>', replace = "https://github.com/orhun/git-cliff" },
+]
+# render body even when there are no releases to process
+# render_always = true
+# output file path
+# output = "test.md"
+
+[git]
+# Parse commits according to the conventional commits specification.
+# See https://www.conventionalcommits.org
+conventional_commits = true
+# Exclude commits that do not match the conventional commits specification.
+filter_unconventional = false
+# Require all commits to be conventional.
+# Takes precedence over filter_unconventional.
+require_conventional = false
+# Split commits on newlines, treating each line as an individual commit.
+split_commits = false
+# An array of regex based parsers to modify commit messages prior to further processing.
+commit_preprocessors = [
+    # Replace issue numbers with link templates to be updated in `changelog.postprocessors`.
+    #{ pattern = '\((\w+\s)?#([0-9]+)\)', replace = "([#${2}](<REPO>/issues/${2}))"},
+    # Check spelling of the message using https://github.com/crate-ci/typos.
+    #{ pattern = '.*', replace_command = 'typos --write-changes -' },
+]
+# Prevent commits that are breaking from being excluded by commit parsers.
+protect_breaking_commits = false
+# An array of regex based parsers for extracting data from the commit message.
+# Assigns commits to groups.
+# Optionally sets the commit's scope and can decide to exclude commits from further processing.
+commit_parsers = [
+    { message = "^feat", group = "<!-- 0 -->🚀 Features" },
+    { message = "^fix", group = "<!-- 1 -->🐛 Bug Fixes" },
+    { message = "^doc", group = "<!-- 3 -->📚 Documentation" },
+    { message = "^perf", group = "<!-- 4 -->⚡ Performance" },
+    { message = "^refactor", group = "<!-- 2 -->🚜 Refactor" },
+    { message = "^style", group = "<!-- 5 -->🎨 Styling" },
+    { message = "^test", group = "<!-- 6 -->🧪 Testing" },
+    { message = "^chore\\(release\\): prepare for", skip = true },
+    { message = "^chore\\(deps.*\\)", skip = true },
+    { message = "^chore\\(pr\\)", skip = true },
+    { message = "^chore\\(pull\\)", skip = true },
+    { message = "^chore|^ci", group = "<!-- 7 -->⚙️ Miscellaneous Tasks" },
+    { body = ".*security", group = "<!-- 8 -->🛡️ Security" },
+    { message = "^revert", group = "<!-- 9 -->◀️ Revert" },
+    # Include non-conventional commits only if they have a JIRA ticket
+    { message = "eaflood\\.atlassian\\.net/browse/[A-Z]+-[0-9]+", group = "<!-- 99 -->📋 Additional changes" },
+    # Skip everything else (no semantic prefix and no ticket)
+    { message = ".*", skip = true },
+]
+# Exclude commits that are not matched by any commit parser.
+# filter_commits = false
+# An array of link parsers for extracting external references, and turning them into URLs, using regex.
+link_parsers = [
+    { pattern = "https://eaflood\\.atlassian\\.net/browse/([A-Z]+-[0-9]+)", href = "https://eaflood.atlassian.net/browse/$1", text = "$1" },
+]
+# Include only the tags that belong to the current branch.
+use_branch_tags = false
+# Order releases topologically instead of chronologically.
+topo_order = false
+# Order releases topologically instead of chronologically.
+topo_order_commits = true
+# Order of commits in each group/release within the changelog.
+# Allowed values: newest, oldest
+sort_commits = "oldest"
+# Process submodules commits
+recurse_submodules = false
+
+tag_pattern = "([Rr]elease-*|v[0-9]+\\.[0-9]+(\\.[0-9]+)?)"

--- a/pipelines/release-notes/generate-release-notes.sh
+++ b/pipelines/release-notes/generate-release-notes.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# requires https://git-cliff.org/
+# Generate release notes
+# Usage: generate-release-notes.sh [--preview]
+# - With `--preview` it shows what's new since last release tag - use this if you haven't yet tagged the next release
+# - Without `--preview` it shows what was new in the latest release tag (since the previous release tag) - use this if you have already tagged the release
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+
+export CLIFF_CURRENT_REF=$(git rev-parse --abbrev-ref HEAD)
+export CLIFF_CURRENT_SHA_SHORT=$(git rev-parse --short HEAD)
+export CLIFF_CURRENT_SHA=$(git rev-parse HEAD)
+export CLIFF_PREVIOUS_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "unknown")
+export CLIFF_PREVIOUS_SHA_SHORT=$(git rev-parse --short "$CLIFF_PREVIOUS_TAG^{commit}" 2>/dev/null || echo "unknown")
+export CLIFF_PREVIOUS_SHA=$(git rev-parse "$CLIFF_PREVIOUS_TAG^{commit}" 2>/dev/null || echo "unknown")
+
+if [ "$1" = "--preview" ]; then
+    MODE="--unreleased"
+else
+    MODE="--latest"
+fi
+
+git-cliff $MODE --strip header --config "$SCRIPT_DIR/cliff.toml"

--- a/src/BackendAccountService.Api.UnitTests/Controllers/AccountsManagementControllerTests.cs
+++ b/src/BackendAccountService.Api.UnitTests/Controllers/AccountsManagementControllerTests.cs
@@ -160,7 +160,7 @@ public class AccountsManagementControllerTests
         validationProblemDetails.Errors.Count.Should().Be(1);
         validationProblemDetails.Errors.FirstOrDefault().Key.Should().Be("Email");
         validationProblemDetails.Errors.FirstOrDefault().Value.First().Should()
-            .Be("Invited user 'test@abc.com' is enrolled already.");
+            .Be("Invited user id '11111111-1111-1111-1111-111111111111' is enrolled already.");
     }
 
     [TestMethod]
@@ -195,7 +195,7 @@ public class AccountsManagementControllerTests
         validationProblemDetails.Errors.Count.Should().Be(1);
         validationProblemDetails.Errors.FirstOrDefault().Key.Should().Be("Email");
         validationProblemDetails.Errors.FirstOrDefault().Value.First().Should()
-            .Be("Invited user 'test@abc.com' doesn't belong to the same organisation.");
+            .Be("Invited user id '11111111-1111-1111-1111-111111111111' doesn't belong to the same organisation.");
     }
 
     [TestMethod]
@@ -279,6 +279,7 @@ public class AccountsManagementControllerTests
             InvitedUser = new()
             {
                 Email = "test@abc.com",
+                UserId = new Guid("11111111-1111-1111-1111-111111111111"),
                 OrganisationId = _existingOrgId,
                 PersonRoleId = 2,
                 ServiceRoleId = 3

--- a/src/BackendAccountService.Api/Controllers/AccountsManagementController.cs
+++ b/src/BackendAccountService.Api/Controllers/AccountsManagementController.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using BackendAccountService.Api.Configuration;
+using BackendAccountService.Core.Helpers;
 using BackendAccountService.Core.Models.Request;
 using BackendAccountService.Core.Services;
 using BackendAccountService.Data.Entities;
@@ -91,12 +92,12 @@ public class AccountsManagementController : ApiControllerBase
             }
 
             ModelState.AddModelError(nameof(request.InvitedUser.Email),
-                $"Invited user '{request.InvitedUser.Email}' doesn't belong to the same organisation.");
+                $"Invited user id '{UserIdentifier.FromInvitedUser(request.InvitedUser)}' doesn't belong to the same organisation.");
         }
         else
         {
             ModelState.AddModelError(nameof(request.InvitedUser.Email),
-                $"Invited user '{request.InvitedUser.Email}' is enrolled already.");
+                $"Invited user id '{UserIdentifier.FromInvitedUser(request.InvitedUser)}' is enrolled already.");
         }
 
         return false;

--- a/src/BackendAccountService.Core.UnitTests/Helpers/UserIdentifierTests.cs
+++ b/src/BackendAccountService.Core.UnitTests/Helpers/UserIdentifierTests.cs
@@ -1,0 +1,72 @@
+using BackendAccountService.Core.Helpers;
+using BackendAccountService.Core.Models.Request;
+using BackendAccountService.Data.Entities;
+using FluentAssertions;
+
+namespace BackendAccountService.Core.UnitTests.Helpers;
+
+[TestClass]
+public class UserIdentifierTests
+{
+    [TestMethod]
+    public void FromUser_WhenUserIdIsSet_ReturnsUserId()
+    {
+        var userId = Guid.NewGuid();
+        var user = new User { Id = 42, UserId = userId };
+
+        var result = UserIdentifier.FromUser(user);
+
+        result.Should().Be(userId.ToString());
+    }
+
+    [TestMethod]
+    public void FromUser_WhenUserIdIsNull_ReturnsDatabaseId()
+    {
+        var user = new User { Id = 42, UserId = null };
+
+        var result = UserIdentifier.FromUser(user);
+
+        result.Should().Be("42");
+    }
+
+    [TestMethod]
+    public void FromUser_WhenUserIdIsEmpty_ReturnsDatabaseId()
+    {
+        var user = new User { Id = 99, UserId = Guid.Empty };
+
+        var result = UserIdentifier.FromUser(user);
+
+        result.Should().Be("99");
+    }
+
+    [TestMethod]
+    public void FromInvitedUser_WhenUserIdIsSet_ReturnsUserId()
+    {
+        var userId = Guid.NewGuid();
+        var invitedUser = new InvitedUser { UserId = userId };
+
+        var result = UserIdentifier.FromInvitedUser(invitedUser);
+
+        result.Should().Be(userId.ToString());
+    }
+
+    [TestMethod]
+    public void FromInvitedUser_WhenUserIdIsNull_ReturnsUnspecified()
+    {
+        var invitedUser = new InvitedUser { UserId = null };
+
+        var result = UserIdentifier.FromInvitedUser(invitedUser);
+
+        result.Should().Be("unspecified-user-id");
+    }
+
+    [TestMethod]
+    public void FromInvitedUser_WhenUserIdIsEmpty_ReturnsUnspecified()
+    {
+        var invitedUser = new InvitedUser { UserId = Guid.Empty };
+
+        var result = UserIdentifier.FromInvitedUser(invitedUser);
+
+        result.Should().Be("unspecified-user-id");
+    }
+}

--- a/src/BackendAccountService.Core.UnitTests/Services/AccountManagementServiceTests.cs
+++ b/src/BackendAccountService.Core.UnitTests/Services/AccountManagementServiceTests.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using BackendAccountService.Core.Helpers;
 using BackendAccountService.Core.Models.Request;
 using BackendAccountService.Core.Services;
 using BackendAccountService.Core.UnitTests.TestHelpers;
@@ -322,8 +323,11 @@ public class AccountManagementServiceTests
 
         var differentOrganisationId = new Guid("00000000-0000-0000-0000-000000000003");
 
-        //Act & Assert
-        await Assert.ThrowsExactlyAsync<ValidationException>(async () => await _sut.ReInviteUserAsync(new InvitedUser
+        var invitedDbUser = _accountContext.Users.Single(x => x.Email == initialInviteRequest.InvitedUser.Email);
+        var expectedUserId = UserIdentifier.FromUser(invitedDbUser);
+
+        var ex = await Assert.ThrowsExactlyAsync<ValidationException>(async () => await _sut.ReInviteUserAsync(
+            new InvitedUser
             {
                 Email = initialInviteRequest.InvitedUser.Email,
                 OrganisationId = differentOrganisationId,
@@ -333,5 +337,8 @@ public class AccountManagementServiceTests
             },
             initialInviteRequest.InvitingUser));
 
+        ex.Message.Should().Be(
+            $"Invited user id '{expectedUserId}' doesn't belong to the same organisation.");
+        ex.Message.Should().NotContain(initialInviteRequest.InvitedUser.Email);
     }
 }

--- a/src/BackendAccountService.Core/Helpers/UserIdentifier.cs
+++ b/src/BackendAccountService.Core/Helpers/UserIdentifier.cs
@@ -1,0 +1,28 @@
+using System.Globalization;
+using BackendAccountService.Core.Models.Request;
+using BackendAccountService.Data.Entities;
+
+namespace BackendAccountService.Core.Helpers;
+
+public static class UserIdentifier
+{
+    public static string FromUser(User user)
+    {
+        if (user.UserId is { } uid && uid != Guid.Empty)
+        {
+            return uid.ToString();
+        }
+
+        return user.Id.ToString(CultureInfo.InvariantCulture);
+    }
+
+    public static string FromInvitedUser(InvitedUser invitedUser)
+    {
+        if (invitedUser.UserId is { } uid && uid != Guid.Empty)
+        {
+            return uid.ToString();
+        }
+
+        return "unspecified-user-id";
+    }
+}

--- a/src/BackendAccountService.Core/Services/AccountManagementService.cs
+++ b/src/BackendAccountService.Core/Services/AccountManagementService.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using BackendAccountService.Core.Helpers;
 using BackendAccountService.Core.Models.Request;
 using BackendAccountService.Data.Entities;
 using BackendAccountService.Data.Infrastructure;
@@ -93,7 +94,8 @@ public class AccountManagementService : IAccountManagementService
 
         if (invitedUserOrganisationConnection is null)
         {
-            throw new ValidationException($"Invited user '{invitedUser.Email}' doesn't belong to the same organisation.");
+            throw new ValidationException(
+                $"Invited user id '{UserIdentifier.FromUser(invited)}' doesn't belong to the same organisation.");
         }
 
         invitedUserOrganisationConnection.PersonRoleId = invitedUser.PersonRoleId;


### PR DESCRIPTION
## What

Adds `UserIdentifier` to resolve id from `User` / `InvitedUser` consistently. 
Unit tests updated for controller and service behaviour.

## Why

Production error flows were exposing **PII** in validation-related messages (AMCR-131). Using identifiers instead of email reduces personal data in logs and client-visible errors while keeping supportability.

## Ticket url

* https://eaflood.atlassian.net/browse/AMCR-131
