### PR TITLE
fix: Remove organisation cascade and identity erasure from Approved Person rejection

### DIFF
--- a/src/BackendAccountService.Core.UnitTests/Services/RegulatorServiceTests.cs
+++ b/src/BackendAccountService.Core.UnitTests/Services/RegulatorServiceTests.cs
@@ -503,7 +503,7 @@ public class RegulatorServiceTests
 
     [TestMethod]
     public async Task
-        When_Update_Enrolment_Is_Requested_And_Approved_Person_Is_Rejected_Then_Save_Rejected_Comments_And_Soft_Delete_Organisation_And_Related_Records_And_Return_Success()
+        When_Update_Enrolment_Is_Requested_And_Approved_Person_Is_Rejected_Then_Save_Rejected_Comments_And_Do_Not_Cascade_Delete_Organisation()
     {
         //Act
         var result = await
@@ -512,9 +512,9 @@ public class RegulatorServiceTests
                 RejectedComment);
 
         //Assert
-
         result.Succeeded.Should().BeTrue();
         result.ErrorMessage.Should().BeEmpty();
+
         var rejectedEnrolment = _dbContext.Enrolments.IgnoreQueryFilters().SingleOrDefault(e =>
             e.ExternalId == ApprovedEnrolmentId2 && e.ServiceRoleId == ServiceRole.Packaging.ApprovedPerson.Id
                                              && e.EnrolmentStatusId == EnrolmentStatus.Rejected
@@ -524,30 +524,17 @@ public class RegulatorServiceTests
         _dbContext.RegulatorComments
             .SingleOrDefault(e => e.EnrolmentId == rejectedEnrolment.Id && e.RejectedComments.Equals(RejectedComment))
             .Should().NotBeNull();
-        _dbContext.Organisations.IgnoreQueryFilters()
-            .SingleOrDefault(org => org.ExternalId == OrganisationId && org.IsDeleted).Should().NotBeNull();
-        _dbContext.PersonOrganisationConnections.IgnoreQueryFilters()
-            .Any(con => con.Organisation.ExternalId == OrganisationId && !con.IsDeleted).Should().BeFalse();
 
-        _dbContext.Users.IgnoreQueryFilters().Any(user =>
-                user.Person.OrganisationConnections.Where(org =>
-                        org.Organisation.ExternalId == OrganisationId)
-                    .Select(org => org.Person.UserId).Contains(user.Id) && !user.IsDeleted &&
-                user.UserId != MultiOrgUserId)
-            .Should().BeFalse();
+        // Organisation must NOT be soft-deleted
+        _dbContext.Organisations
+            .SingleOrDefault(org => org.ExternalId == OrganisationId).Should().NotBeNull();
 
+        // Other connections on the org must NOT be soft-deleted
+        _dbContext.PersonOrganisationConnections
+            .Any(con => con.Organisation.ExternalId == OrganisationId && !con.IsDeleted).Should().BeTrue();
+
+        // Other users on the org must NOT be soft-deleted
         _dbContext.Users.Any(user => user.UserId == MultiOrgUserId && !user.IsDeleted).Should().BeTrue();
-
-        _dbContext.Persons.IgnoreQueryFilters().Any(person =>
-            person.OrganisationConnections.Where(org => org.Organisation.ExternalId == OrganisationId)
-                .Select(org => org.Person.UserId).Contains(person.Id) && !person.IsDeleted &&
-            person.User.UserId != MultiOrgUserId).Should().BeFalse();
-
-        _dbContext.Persons.Any(person => person.User.UserId == MultiOrgUserId && !person.IsDeleted).Should().BeTrue();
-
-        _dbContext.Enrolments.IgnoreQueryFilters()
-            .Any(enrolments => enrolments.Connection.Organisation.ExternalId == OrganisationId && !enrolments.IsDeleted)
-            .Should().BeFalse();
     }
 
     [TestMethod]
@@ -577,7 +564,7 @@ public class RegulatorServiceTests
 
     [TestMethod]
     public async Task
-        When_Update_Enrolment_Is_Requested_And_Approved_Person_Is_Rejected_Then_Set_user_id_to_default_Guid()
+        When_Update_Enrolment_Is_Requested_And_Approved_Person_Is_Rejected_Then_Do_Not_Set_user_id_to_default_Guid()
     {
         //Act
         var result = await
@@ -586,21 +573,15 @@ public class RegulatorServiceTests
                 RejectedComment);
 
         //Assert
-
         result.Succeeded.Should().BeTrue();
         result.ErrorMessage.Should().BeEmpty();
-        var rejectedEnrolment = _dbContext.Enrolments.IgnoreQueryFilters().SingleOrDefault(e =>
-            e.ExternalId == ApprovedEnrolmentId2 && e.ServiceRoleId == ServiceRole.Packaging.ApprovedPerson.Id
-                                             && e.EnrolmentStatusId == EnrolmentStatus.Rejected
-                                             && e.IsDeleted);
-        rejectedEnrolment.Should().NotBeNull();
 
-        var user = _dbContext.Users.IgnoreQueryFilters().SingleOrDefault(e => e.UserId == Guid.Empty);
+        // No user should have UserId blanked to Guid.Empty
+        _dbContext.Users.IgnoreQueryFilters()
+            .SingleOrDefault(e => e.UserId == Guid.Empty).Should().BeNull();
 
-        Assert.IsNotNull(user);
-        Assert.AreSame(ApprovedUser2ProducerEmail, user.Email);
-        _dbContext.Users.Any(user1 => user1.UserId == ApprovedUserId2).Should().BeFalse();
-        _dbContext.Users.Any(user1 => user1.UserId == RegulatorUserId).Should().BeTrue();
+        // The rejected AP's user record should retain its original UserId
+        _dbContext.Users.Any(user1 => user1.UserId == ApprovedUserId2).Should().BeTrue();
     }
 
     [TestMethod]

--- a/src/BackendAccountService.Core/Services/RegulatorService.cs
+++ b/src/BackendAccountService.Core/Services/RegulatorService.cs
@@ -160,78 +160,8 @@ public class RegulatorService : ServiceBase, IRegulatorService
             return (true, string.Empty);
         }
 
-        SoftDeleteOrganisation(organisationId);
-        SetDefaultUserIdForRejectedApprovedPerson(enrolment);
-
         await _accountsDbContext.SaveChangesAsync(userId, organisationId);
         return (true, string.Empty);
-    }
-
-    private static void SetDefaultUserIdForRejectedApprovedPerson(Enrolment enrolment)
-    {
-        if (enrolment.ServiceRoleId == ServiceRole.Packaging.ApprovedPerson.Id)
-        {
-            enrolment.Connection.Person.User.UserId = Guid.Empty;
-        }
-    }
-
-    private void SoftDeleteOrganisation(Guid organisationId)
-    {
-        _accountsDbContext.Enrolments.Where(enrolment =>
-            enrolment.Connection.Organisation.ExternalId == organisationId).ToList().ForEach(x =>
-        {
-            x.IsDeleted = true;
-        });
-
-        _accountsDbContext.PersonOrganisationConnections.Where(connection =>
-            connection.Organisation.ExternalId == organisationId).ToList().ForEach(x =>
-        {
-            x.IsDeleted = true;
-        });
-
-        _accountsDbContext.Organisations.Where(organisation =>
-            organisation.ExternalId == organisationId).ToList().ForEach(x =>
-        {
-            x.IsDeleted = true;
-        });
-
-        _accountsDbContext.OrganisationsConnections.Where(connection =>
-            connection.FromOrganisation.ExternalId == organisationId || connection.ToOrganisation.ExternalId == organisationId).ToList().ForEach(x =>
-        {
-            x.IsDeleted = true;
-        });
-
-        _accountsDbContext.SelectedSchemes.Where(scheme =>
-            scheme.OrganisationConnection.FromOrganisation.ExternalId == organisationId || scheme.OrganisationConnection.ToOrganisation.ExternalId == organisationId).ToList().ForEach(x =>
-        {
-            x.IsDeleted = true;
-        });
-
-        var organisationUsersList = _accountsDbContext.PersonOrganisationConnections
-            .Where(org => org.Organisation.ExternalId == organisationId)
-            .Select(org => org.Person.User.UserId).ToList();
-
-        var usersToSoftDelete = new List<Guid?>();
-
-        foreach (var userId in organisationUsersList)
-        {
-            if (!_organisationService.IsUserAssociatedWithMultipleOrganisations(userId))
-            {
-                usersToSoftDelete.Add(userId);
-            }
-        }
-
-        _accountsDbContext.Users.Where(user =>
-            usersToSoftDelete.Contains(user.UserId)).ToList().ForEach(x =>
-        {
-            x.IsDeleted = true;
-        });
-
-        _accountsDbContext.Persons.Where(person =>
-            usersToSoftDelete.Contains(person.User.UserId)).ToList().ForEach(x =>
-        {
-            x.IsDeleted = true;
-        });
     }
 
     public int GetRegulatorNationId(Guid userId)


### PR DESCRIPTION
When a regulator rejected an Approved Person enrolment, the backend cascaded soft-deletion across the entire organisation — all users, enrolments, connections, and compliance scheme relationships and set the rejected AP's User.UserId to Guid.Empty, permanently severing their Azure AD B2C identity link with no self-service recovery path.

This was disproportionate for any scenario. Even for initial registration rejection, destroying the organisation prevents another person from applying as AP, and blanking the UserId prevents the rejected person from ever re-registering or joining a different organisation. The existing RemoveApprovedPerson/AddRemoveApprovedPerson endpoints already handle AP removal surgically without cascading.

AP rejection now behaves consistently: the enrolment is marked rejected and soft-deleted, the regulator's comment is stored, and the organisation and all other records remain intact.

Updated the two unit tests that previously asserted the cascade and Guid.Empty behaviour to assert the opposite.

Fixes https://eaflood.atlassian.net/browse/AMCR-157