### PR TITLE
Run new integration tests in CI builds

### DIFF
--- a/src/BackendAccountService.IntegrationTests/Infrastructure/IntegrationTestBase.cs
+++ b/src/BackendAccountService.IntegrationTests/Infrastructure/IntegrationTestBase.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 namespace BackendAccountService.IntegrationTests.Infrastructure;
 
 [Collection(AccountApiCollection.Name)]
+[Trait("Category", "IntegrationTest")]
 public abstract class IntegrationTestBase
 {
     protected AccountApiFactory Factory { get; }


### PR DESCRIPTION
The new "BackendAccountService.IntegrationTests" added in
d5d4d8f624db322a135b2de1495779c28a4aa203 as part of PR #25 were not yet being run in CI,
this patch causes them to be included in the CI runs, which means when any
failures will now be caught during CI builds.

---

Every test class in BackendAccountService.IntegrationTests inherits from
IntegrationTestBase, so a single class-level [Trait("Category",
"IntegrationTest")] is enough -- xUnit walks the class hierarchy when
collecting traits.

---

The shared CI template (analyse-and-test.yaml#L104) already runs `dotnet
test **/*[Ii]ntegration[Tt]ests/*.csproj --filter
"Category=IntegrationTest"`, which picks up both this project and
BackendAccountService.Data.IntegrationTests in the same step.

https://github.com/DEFRA/epr-webapps-code-deploy-templates/blob/bce3de843ed90d9d9ffecc535bf5692b81f612ef/templates/analyse-and-test.yaml#L104

This was enabled for this repo in 15c7aa6fc5b46082d5746d511d872882b13355e1


# Ticket

Supporting work for https://eaflood.atlassian.net/browse/AMCR-212