### PR TITLE
ci: Use github pipeline template

### DIFF
--- a/pipelines/azure-pipelines-validation-data-api.yml
+++ b/pipelines/azure-pipelines-validation-data-api.yml
@@ -44,9 +44,10 @@ variables:
 resources:
   repositories:
     - repository: CommonTemplates
-      name: RWD-CPR-EPR4P-ADO/epr-webapps-code-deploy-templates
-      type: git
+      name: defra/epr-webapps-code-deploy-templates
+      type: github
       ref: main
+      endpoint: DEFRA
 
 extends:
   template: epr-build-pipeline.yaml@CommonTemplates


### PR DESCRIPTION
azure devops repo for this is deprecated, switch to primary github copy

deprecation warning spotted in build https://dev.azure.com/defragovuk/RWD-CPR-EPR4P-ADO/_build/results?buildId=1283349&view=logs&s=6c3924a3-f28f-52d8-1b5a-c907c0271ee2

# Ticket

Supporting work for https://eaflood.atlassian.net/browse/AMCR-212