### PR TITLE
Dependency security updates

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,13 +4,4 @@
         <CodeAnalysisRuleSet>..\SonarAnalyzer.ruleset</CodeAnalysisRuleSet>
     </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference
-				Include="SonarAnalyzer.CSharp"
-				Version="9.30.0.95878"
-				PrivateAssets="all"
-				Condition="$(MSBuildProjectExtension) == '.csproj'"
-        />
-    </ItemGroup>
-
 </Project>

--- a/src/BackendAccountService.Api.UnitTests/BackendAccountService.Api.UnitTests.csproj
+++ b/src/BackendAccountService.Api.UnitTests/BackendAccountService.Api.UnitTests.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.18.1" />
-    <PackageReference Include="AutoMapper" Version="14.0.0" />
+    <PackageReference Include="MagicMapper" Version="14.0.1" />
     <PackageReference Include="Azure.Identity" Version="1.16.0" />
     <PackageReference Include="coverlet.msbuild" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>

--- a/src/BackendAccountService.Api.UnitTests/BackendAccountService.Api.UnitTests.csproj
+++ b/src/BackendAccountService.Api.UnitTests/BackendAccountService.Api.UnitTests.csproj
@@ -38,6 +38,6 @@
 		<ProjectReference Include="..\BackendAccountService.Core\BackendAccountService.Core.csproj" />
 	</ItemGroup>
 	<ItemGroup>
-	  <PackageReference Update="SonarAnalyzer.CSharp" Version="10.15.0.120848" />
+	  <PackageReference Include="SonarAnalyzer.CSharp" Version="10.15.0.120848" PrivateAssets="all" />
 	</ItemGroup>
 </Project>

--- a/src/BackendAccountService.Api.UnitTests/BackendAccountService.Api.UnitTests.csproj
+++ b/src/BackendAccountService.Api.UnitTests/BackendAccountService.Api.UnitTests.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Moq" Version="4.20.72" />
 	<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.Text.Json" Version="8.0.6" />
+    <PackageReference Include="System.Text.Json" Version="10.0.3" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
 	  
   </ItemGroup>

--- a/src/BackendAccountService.Api.UnitTests/BackendAccountService.Api.UnitTests.csproj
+++ b/src/BackendAccountService.Api.UnitTests/BackendAccountService.Api.UnitTests.csproj
@@ -12,15 +12,15 @@
     <PackageReference Include="AutoFixture" Version="4.18.1" />
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.18.1" />
     <PackageReference Include="MagicMapper" Version="14.0.1" />
-    <PackageReference Include="Azure.Identity" Version="1.16.0" />
+    <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <PackageReference Include="coverlet.msbuild" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.10.4" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.10.4" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.11.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.11.1" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -38,6 +38,6 @@
 		<ProjectReference Include="..\BackendAccountService.Core\BackendAccountService.Core.csproj" />
 	</ItemGroup>
 	<ItemGroup>
-	  <PackageReference Include="SonarAnalyzer.CSharp" Version="10.15.0.120848" PrivateAssets="all" />
+	  <PackageReference Include="SonarAnalyzer.CSharp" Version="10.27.0.140913" PrivateAssets="all" />
 	</ItemGroup>
 </Project>

--- a/src/BackendAccountService.Api/BackendAccountService.Api.csproj
+++ b/src/BackendAccountService.Api/BackendAccountService.Api.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.28" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.9.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
-    <PackageReference Include="System.Text.Json" Version="8.0.6" />
+    <PackageReference Include="System.Text.Json" Version="10.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BackendAccountService.Api/BackendAccountService.Api.csproj
+++ b/src/BackendAccountService.Api/BackendAccountService.Api.csproj
@@ -44,6 +44,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="SonarAnalyzer.CSharp" Version="10.15.0.120848" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.15.0.120848" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/src/BackendAccountService.Api/BackendAccountService.Api.csproj
+++ b/src/BackendAccountService.Api/BackendAccountService.Api.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="14.0.0" />
+    <PackageReference Include="MagicMapper" Version="14.0.1" />
     <PackageReference Include="Azure.Identity" Version="1.16.0" />
     <PackageReference Include="FluentValidation" Version="12.0.0" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.1" />

--- a/src/BackendAccountService.Api/BackendAccountService.Api.csproj
+++ b/src/BackendAccountService.Api/BackendAccountService.Api.csproj
@@ -12,23 +12,23 @@
 
   <ItemGroup>
     <PackageReference Include="MagicMapper" Version="14.0.1" />
-    <PackageReference Include="Azure.Identity" Version="1.16.0" />
-    <PackageReference Include="FluentValidation" Version="12.0.0" />
+    <PackageReference Include="Azure.Identity" Version="1.21.0" />
+    <PackageReference Include="FluentValidation" Version="12.1.1" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.1" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.3.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.7">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.3.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.28">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.7">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.28">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />    
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.8" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.7.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.0" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.28" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.9.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
     <PackageReference Include="System.Text.Json" Version="8.0.6" />
   </ItemGroup>
 
@@ -44,6 +44,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.15.0.120848" PrivateAssets="all" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.27.0.140913" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/src/BackendAccountService.Core.UnitTests/BackendAccountService.Core.UnitTests.csproj
+++ b/src/BackendAccountService.Core.UnitTests/BackendAccountService.Core.UnitTests.csproj
@@ -11,17 +11,17 @@
   <ItemGroup>
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.18.1" />
     <PackageReference Include="MagicMapper" Version="14.0.1" />
-    <PackageReference Include="Azure.Identity" Version="1.16.0" />
+    <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <PackageReference Include="AwesomeAssertions" Version="9.4.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.28" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
     <PackageReference Include="coverlet.msbuild" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.10.4" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.10.4" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.11.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.11.1" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -38,7 +38,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.15.0.120848" PrivateAssets="all" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.27.0.140913" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/src/BackendAccountService.Core.UnitTests/BackendAccountService.Core.UnitTests.csproj
+++ b/src/BackendAccountService.Core.UnitTests/BackendAccountService.Core.UnitTests.csproj
@@ -38,7 +38,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="SonarAnalyzer.CSharp" Version="10.15.0.120848" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.15.0.120848" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/src/BackendAccountService.Core.UnitTests/BackendAccountService.Core.UnitTests.csproj
+++ b/src/BackendAccountService.Core.UnitTests/BackendAccountService.Core.UnitTests.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <PackageReference Include="AwesomeAssertions" Version="9.4.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.28" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
     <PackageReference Include="coverlet.msbuild" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/BackendAccountService.Core.UnitTests/BackendAccountService.Core.UnitTests.csproj
+++ b/src/BackendAccountService.Core.UnitTests/BackendAccountService.Core.UnitTests.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.18.1" />
-    <PackageReference Include="AutoMapper" Version="14.0.0" />
+    <PackageReference Include="MagicMapper" Version="14.0.1" />
     <PackageReference Include="Azure.Identity" Version="1.16.0" />
     <PackageReference Include="AwesomeAssertions" Version="9.4.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.7" />

--- a/src/BackendAccountService.Core.UnitTests/BackendAccountService.Core.UnitTests.csproj
+++ b/src/BackendAccountService.Core.UnitTests/BackendAccountService.Core.UnitTests.csproj
@@ -28,7 +28,7 @@
     </PackageReference>
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.Text.Json" Version="8.0.6" />
+    <PackageReference Include="System.Text.Json" Version="10.0.3" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 

--- a/src/BackendAccountService.Core/BackendAccountService.Core.csproj
+++ b/src/BackendAccountService.Core/BackendAccountService.Core.csproj
@@ -23,15 +23,15 @@
   
   <ItemGroup>
     <PackageReference Include="MagicMapper" Version="14.0.1" />
-    <PackageReference Include="Azure.Identity" Version="1.16.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.3.0" />
+    <PackageReference Include="Azure.Identity" Version="1.21.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.3.11" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.1" />
     <PackageReference Include="System.Text.Json" Version="8.0.6" />
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.15.0.120848" PrivateAssets="all" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.27.0.140913" PrivateAssets="all" />
   </ItemGroup>
   
 </Project>

--- a/src/BackendAccountService.Core/BackendAccountService.Core.csproj
+++ b/src/BackendAccountService.Core/BackendAccountService.Core.csproj
@@ -31,7 +31,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Update="SonarAnalyzer.CSharp" Version="10.15.0.120848" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.15.0.120848" PrivateAssets="all" />
   </ItemGroup>
   
 </Project>

--- a/src/BackendAccountService.Core/BackendAccountService.Core.csproj
+++ b/src/BackendAccountService.Core/BackendAccountService.Core.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.3.11" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.1" />
-    <PackageReference Include="System.Text.Json" Version="8.0.6" />
+    <PackageReference Include="System.Text.Json" Version="10.0.3" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/BackendAccountService.Core/BackendAccountService.Core.csproj
+++ b/src/BackendAccountService.Core/BackendAccountService.Core.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="14.0.0" />
+    <PackageReference Include="MagicMapper" Version="14.0.1" />
     <PackageReference Include="Azure.Identity" Version="1.16.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.3.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />

--- a/src/BackendAccountService.Data.IntegrationTests/BackendAccountService.Data.IntegrationTests.csproj
+++ b/src/BackendAccountService.Data.IntegrationTests/BackendAccountService.Data.IntegrationTests.csproj
@@ -45,7 +45,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Update="SonarAnalyzer.CSharp" Version="10.15.0.120848" />
+      <PackageReference Include="SonarAnalyzer.CSharp" Version="10.15.0.120848" PrivateAssets="all" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/BackendAccountService.Data.IntegrationTests/BackendAccountService.Data.IntegrationTests.csproj
+++ b/src/BackendAccountService.Data.IntegrationTests/BackendAccountService.Data.IntegrationTests.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
         <PackageReference Include="MagicMapper" Version="14.0.1" />
-        <PackageReference Include="Azure.Identity" Version="1.16.0" />
+        <PackageReference Include="Azure.Identity" Version="1.21.0" />
         <PackageReference Include="BouncyCastle.Cryptography" Version="2.6.2" />
         <PackageReference Include="coverlet.msbuild" Version="6.0.4">
           <PrivateAssets>all</PrivateAssets>
@@ -18,11 +18,11 @@
         </PackageReference>
         <PackageReference Include="AwesomeAssertions" Version="9.4.0" />
         <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.3.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.3.11" />
         <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
         <PackageReference Include="Moq" Version="4.20.72" />
-        <PackageReference Include="xunit" Version="2.9.2" />
+        <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
           <PrivateAssets>all</PrivateAssets>
@@ -34,8 +34,8 @@
         <PackageReference Include="System.Net.Http" Version="4.3.4" />
         <PackageReference Include="System.Text.Json" Version="8.0.6" />
         <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-        <PackageReference Include="Testcontainers" Version="4.7.0" />
-        <PackageReference Include="Testcontainers.MsSql" Version="4.7.0" />
+        <PackageReference Include="Testcontainers" Version="4.12.0" />
+        <PackageReference Include="Testcontainers.MsSql" Version="4.12.0" />
     </ItemGroup>
 
     <ItemGroup>
@@ -45,7 +45,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="SonarAnalyzer.CSharp" Version="10.15.0.120848" PrivateAssets="all" />
+      <PackageReference Include="SonarAnalyzer.CSharp" Version="10.27.0.140913" PrivateAssets="all" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/BackendAccountService.Data.IntegrationTests/BackendAccountService.Data.IntegrationTests.csproj
+++ b/src/BackendAccountService.Data.IntegrationTests/BackendAccountService.Data.IntegrationTests.csproj
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AutoMapper" Version="14.0.0" />
+        <PackageReference Include="MagicMapper" Version="14.0.1" />
         <PackageReference Include="Azure.Identity" Version="1.16.0" />
         <PackageReference Include="BouncyCastle.Cryptography" Version="2.6.2" />
         <PackageReference Include="coverlet.msbuild" Version="6.0.4">

--- a/src/BackendAccountService.Data.IntegrationTests/BackendAccountService.Data.IntegrationTests.csproj
+++ b/src/BackendAccountService.Data.IntegrationTests/BackendAccountService.Data.IntegrationTests.csproj
@@ -32,7 +32,7 @@
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="System.Net.Http" Version="4.3.4" />
-        <PackageReference Include="System.Text.Json" Version="8.0.6" />
+        <PackageReference Include="System.Text.Json" Version="10.0.3" />
         <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
         <PackageReference Include="Testcontainers" Version="4.12.0" />
         <PackageReference Include="Testcontainers.MsSql" Version="4.12.0" />

--- a/src/BackendAccountService.Data.LaTestSeeder/BackendAccountService.Data.LaTestSeeder.csproj
+++ b/src/BackendAccountService.Data.LaTestSeeder/BackendAccountService.Data.LaTestSeeder.csproj
@@ -20,7 +20,7 @@
       <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
       <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
-      <PackageReference Include="System.Text.Json" Version="8.0.6" />
+      <PackageReference Include="System.Text.Json" Version="10.0.3" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/BackendAccountService.Data.LaTestSeeder/BackendAccountService.Data.LaTestSeeder.csproj
+++ b/src/BackendAccountService.Data.LaTestSeeder/BackendAccountService.Data.LaTestSeeder.csproj
@@ -15,11 +15,11 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Azure.Identity" Version="1.16.0" />
-      <PackageReference Include="bogus" Version="35.6.4" />
+      <PackageReference Include="Azure.Identity" Version="1.21.0" />
+      <PackageReference Include="bogus" Version="35.6.5" />
       <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
       <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
-      <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
       <PackageReference Include="System.Text.Json" Version="8.0.6" />
     </ItemGroup>
 
@@ -34,7 +34,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="SonarAnalyzer.CSharp" Version="10.15.0.120848" PrivateAssets="all" />
+      <PackageReference Include="SonarAnalyzer.CSharp" Version="10.27.0.140913" PrivateAssets="all" />
     </ItemGroup>
 
 

--- a/src/BackendAccountService.Data.LaTestSeeder/BackendAccountService.Data.LaTestSeeder.csproj
+++ b/src/BackendAccountService.Data.LaTestSeeder/BackendAccountService.Data.LaTestSeeder.csproj
@@ -34,7 +34,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Update="SonarAnalyzer.CSharp" Version="10.15.0.120848" />
+      <PackageReference Include="SonarAnalyzer.CSharp" Version="10.15.0.120848" PrivateAssets="all" />
     </ItemGroup>
 
 

--- a/src/BackendAccountService.Data.UnitTests/BackendAccountService.Data.UnitTests.csproj
+++ b/src/BackendAccountService.Data.UnitTests/BackendAccountService.Data.UnitTests.csproj
@@ -37,7 +37,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="SonarAnalyzer.CSharp" Version="10.15.0.120848" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.15.0.120848" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/src/BackendAccountService.Data.UnitTests/BackendAccountService.Data.UnitTests.csproj
+++ b/src/BackendAccountService.Data.UnitTests/BackendAccountService.Data.UnitTests.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.11.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.11.1" />
-    <PackageReference Include="System.Text.Json" Version="8.0.6" />
+    <PackageReference Include="System.Text.Json" Version="10.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BackendAccountService.Data.UnitTests/BackendAccountService.Data.UnitTests.csproj
+++ b/src/BackendAccountService.Data.UnitTests/BackendAccountService.Data.UnitTests.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-	<PackageReference Include="Azure.Identity" Version="1.16.0" />
+	<PackageReference Include="Azure.Identity" Version="1.21.0" />
 	<PackageReference Include="coverlet.msbuild" Version="6.0.4">
 		<PrivateAssets>all</PrivateAssets>
 		<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -20,11 +20,11 @@
 		<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	</PackageReference>
     <PackageReference Include="AwesomeAssertions" Version="9.4.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.28" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.10.4" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.10.4" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.11.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.11.1" />
     <PackageReference Include="System.Text.Json" Version="8.0.6" />
   </ItemGroup>
 
@@ -37,7 +37,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.15.0.120848" PrivateAssets="all" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.27.0.140913" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/src/BackendAccountService.Data/BackendAccountService.Data.csproj
+++ b/src/BackendAccountService.Data/BackendAccountService.Data.csproj
@@ -11,20 +11,20 @@
   </Target>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.16.0" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.7">
+    <PackageReference Include="Azure.Identity" Version="1.21.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.28">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.7" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.7">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.28" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.28">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
-    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.14.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.0.1" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.19.1" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.19.1" />
     <PackageReference Include="System.Text.Json" Version="8.0.6" />
   </ItemGroup>
 
@@ -64,7 +64,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.15.0.120848" PrivateAssets="all" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.27.0.140913" PrivateAssets="all" />
   </ItemGroup>
   
 </Project>

--- a/src/BackendAccountService.Data/BackendAccountService.Data.csproj
+++ b/src/BackendAccountService.Data/BackendAccountService.Data.csproj
@@ -64,7 +64,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Update="SonarAnalyzer.CSharp" Version="10.15.0.120848" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.15.0.120848" PrivateAssets="all" />
   </ItemGroup>
   
 </Project>

--- a/src/BackendAccountService.Data/BackendAccountService.Data.csproj
+++ b/src/BackendAccountService.Data/BackendAccountService.Data.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.19.1" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.19.1" />
-    <PackageReference Include="System.Text.Json" Version="8.0.6" />
+    <PackageReference Include="System.Text.Json" Version="10.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BackendAccountService.IntegrationTests/BackendAccountService.IntegrationTests.csproj
+++ b/src/BackendAccountService.IntegrationTests/BackendAccountService.IntegrationTests.csproj
@@ -21,6 +21,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="9.30.0.95878" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BackendAccountService.IntegrationTests/BackendAccountService.IntegrationTests.csproj
+++ b/src/BackendAccountService.IntegrationTests/BackendAccountService.IntegrationTests.csproj
@@ -21,7 +21,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="9.32.0.97167" PrivateAssets="all" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.27.0.140913" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BackendAccountService.IntegrationTests/BackendAccountService.IntegrationTests.csproj
+++ b/src/BackendAccountService.IntegrationTests/BackendAccountService.IntegrationTests.csproj
@@ -11,17 +11,17 @@
 
   <ItemGroup>
     <PackageReference Include="AwesomeAssertions" Version="9.4.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.28" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="Testcontainers" Version="4.7.0" />
-    <PackageReference Include="Testcontainers.MsSql" Version="4.7.0" />
-    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="Testcontainers" Version="4.12.0" />
+    <PackageReference Include="Testcontainers.MsSql" Version="4.12.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="9.30.0.95878" PrivateAssets="all" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="9.32.0.97167" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BackendAccountService.ValidationData.Api.UnitTests/BackendAccountService.ValidationData.Api.UnitTests.csproj
+++ b/src/BackendAccountService.ValidationData.Api.UnitTests/BackendAccountService.ValidationData.Api.UnitTests.csproj
@@ -28,7 +28,7 @@
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="System.Net.Http" Version="4.3.4" />
-        <PackageReference Include="System.Text.Json" Version="8.0.6" />
+        <PackageReference Include="System.Text.Json" Version="10.0.3" />
         <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     </ItemGroup>
 

--- a/src/BackendAccountService.ValidationData.Api.UnitTests/BackendAccountService.ValidationData.Api.UnitTests.csproj
+++ b/src/BackendAccountService.ValidationData.Api.UnitTests/BackendAccountService.ValidationData.Api.UnitTests.csproj
@@ -38,7 +38,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Update="SonarAnalyzer.CSharp" Version="10.15.0.120848" />
+      <PackageReference Include="SonarAnalyzer.CSharp" Version="10.15.0.120848" PrivateAssets="all" />
     </ItemGroup>
 
 </Project>

--- a/src/BackendAccountService.ValidationData.Api.UnitTests/BackendAccountService.ValidationData.Api.UnitTests.csproj
+++ b/src/BackendAccountService.ValidationData.Api.UnitTests/BackendAccountService.ValidationData.Api.UnitTests.csproj
@@ -9,20 +9,20 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Azure.Identity" Version="1.16.0" />
+        <PackageReference Include="Azure.Identity" Version="1.21.0" />
         <PackageReference Include="coverlet.msbuild" Version="6.0.4">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="AwesomeAssertions" Version="9.4.0" />
         <PackageReference Include="ILogger.Moq" Version="2.0.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.3.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.7" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.3.11" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.28" />
         <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
         <PackageReference Include="Moq" Version="4.20.72" />
-        <PackageReference Include="MSTest.TestAdapter" Version="3.10.4" />
-        <PackageReference Include="MSTest.TestFramework" Version="3.10.4" />
+        <PackageReference Include="MSTest.TestAdapter" Version="3.11.1" />
+        <PackageReference Include="MSTest.TestFramework" Version="3.11.1" />
         <PackageReference Include="coverlet.collector" Version="6.0.4">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -38,7 +38,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="SonarAnalyzer.CSharp" Version="10.15.0.120848" PrivateAssets="all" />
+      <PackageReference Include="SonarAnalyzer.CSharp" Version="10.27.0.140913" PrivateAssets="all" />
     </ItemGroup>
 
 </Project>

--- a/src/BackendAccountService.ValidationData.Api/BackendAccountService.ValidationData.Api.csproj
+++ b/src/BackendAccountService.ValidationData.Api/BackendAccountService.ValidationData.Api.csproj
@@ -4,8 +4,8 @@
         <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Azure.Identity" Version="1.16.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.3.0" />
+        <PackageReference Include="Azure.Identity" Version="1.21.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.3.11" />
         <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
         <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
         <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.6.0" />
@@ -29,6 +29,6 @@
       <ProjectReference Include="..\BackendAccountService.Data\BackendAccountService.Data.csproj" />
     </ItemGroup>
     <ItemGroup>
-      <PackageReference Include="SonarAnalyzer.CSharp" Version="10.15.0.120848" PrivateAssets="all" />
+      <PackageReference Include="SonarAnalyzer.CSharp" Version="10.27.0.140913" PrivateAssets="all" />
     </ItemGroup>
 </Project>

--- a/src/BackendAccountService.ValidationData.Api/BackendAccountService.ValidationData.Api.csproj
+++ b/src/BackendAccountService.ValidationData.Api/BackendAccountService.ValidationData.Api.csproj
@@ -29,6 +29,6 @@
       <ProjectReference Include="..\BackendAccountService.Data\BackendAccountService.Data.csproj" />
     </ItemGroup>
     <ItemGroup>
-      <PackageReference Update="SonarAnalyzer.CSharp" Version="10.15.0.120848" />
+      <PackageReference Include="SonarAnalyzer.CSharp" Version="10.15.0.120848" PrivateAssets="all" />
     </ItemGroup>
 </Project>

--- a/src/BackendAccountService.ValidationData.Api/BackendAccountService.ValidationData.Api.csproj
+++ b/src/BackendAccountService.ValidationData.Api/BackendAccountService.ValidationData.Api.csproj
@@ -10,7 +10,7 @@
         <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
         <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.6.0" />
         <PackageReference Include="System.Net.Http" Version="4.3.4" />
-        <PackageReference Include="System.Text.Json" Version="8.0.6" />
+        <PackageReference Include="System.Text.Json" Version="10.0.3" />
         <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     </ItemGroup>
     <ItemGroup>


### PR DESCRIPTION
1. Bump to latest minor version to get security patches.
2. Skip most major version updates to avoid breaking changes
3. Fix broken layout of sonar dependency (was spread across props & csproj) that breaks automatic upgrade tooling.
4. Bump smallest possible number of dependencies to next major version in order to fix "downgrade" build errors.

Follow up to PR #25

# Ticket

Supporting work for https://eaflood.atlassian.net/browse/AMCR-212