### PR TITLE
ci: Use github deploy templates

### DIFF
--- a/pipelines/Initialise-SQL-db.yaml
+++ b/pipelines/Initialise-SQL-db.yaml
@@ -67,9 +67,10 @@ variables:
 resources:
   repositories:
     - repository: CommonTemplates
-      name: RWD-CPR-EPR4P-ADO/epr-webapps-code-deploy-templates
-      type: git
+      name: defra/epr-webapps-code-deploy-templates
+      type: github
       ref: main
+      endpoint: DEFRA
 
     # The repo will be reference the repo by a release tag (if the branchName parameter contains 'release') otherwise it will pull down the main branch.
     - repository: ReleaseTags

--- a/pipelines/deployment-pipeline-validation-data-api.yaml
+++ b/pipelines/deployment-pipeline-validation-data-api.yaml
@@ -73,9 +73,10 @@ variables:
 resources:
   repositories:
     - repository: CommonTemplates
-      name: RWD-CPR-EPR4P-ADO/epr-webapps-code-deploy-templates
-      type: git
+      name: defra/epr-webapps-code-deploy-templates
+      type: github
       ref: main
+      endpoint: DEFRA
 
     # The repo will be reference the repo by a release tag (if the imageTag parameter contains 'release') otherwise it will pull down the main branch.
     - repository: ReleaseTags


### PR DESCRIPTION
devops repo is deprecated, got a warning during deployment

# Ticket

Supporting work for https://eaflood.atlassian.net/browse/AMCR-212
