### PR TITLE
Dependency upgrades take2, avoiding dotnet 10

### DIFF
--- a/security-updates.sh
+++ b/security-updates.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Run the periodic NuGet bump and verify it didn't quietly cross the
+# net8 shared-framework ceiling on either of the runtime-deployed
+# projects.
+#
+# Depends on https://github.com/dotnet-outdated/dotnet-outdated being installed.
+#
+# This script was created to help avoid a repeat of an upgrade that failed when
+# deployed to a dev environment having passed all CI build & test.
+#
+# Background: BackendAccountService.Api (ASP.NET Core on App Service)
+# and BackendAccountService.ValidationData.Api (Functions in-process v4)
+# both deploy onto net8 hosts that pre-load Microsoft.Extensions.* 8.x
+# from the shared framework before user code runs. A transitive bump
+# pulling in M.Extensions.* >= 10.x (typically via Azure.Identity 1.21
+# -> Azure.Core 1.53 -> Microsoft.Extensions.Hosting.Abstractions 10)
+# will build clean, pass `dotnet test`, and fail at startup on Azure
+# with `Could not load file or assembly 'Microsoft.Extensions.Options,
+# Version=10.0.0.0'`. Test runners don't reproduce it because they
+# don't load the ASP.NET Core / Functions shared framework.
+#
+# Test projects and console tools are unaffected (no shared framework
+# pre-load), so the check is scoped to the two deployed projects only.
+
+set -euo pipefail
+
+SLN=src/BackendAccountService.sln
+DEPLOYED_PROJECTS=(
+    src/BackendAccountService.Api
+    src/BackendAccountService.ValidationData.Api
+)
+
+echo "==> dotnet outdated --version-lock Major --upgrade"
+dotnet outdated --version-lock Major --upgrade "$SLN"
+
+echo
+echo "==> Probing deployed projects for transitive framework-bundled assemblies above net8 ceiling"
+hazards=0
+for p in "${DEPLOYED_PROJECTS[@]}"; do
+    echo "--- $p ---"
+    hits=$(dotnet list "$p" package --include-transitive --framework net8.0 \
+        | grep -E "Microsoft\.(Extensions|AspNetCore)\..* (10|11|12|13|14)\." || true)
+    if [ -n "$hits" ]; then
+        echo "$hits"
+        hazards=$((hazards + 1))
+    else
+        echo "(none)"
+    fi
+done
+
+echo
+if [ "$hazards" -gt 0 ]; then
+    echo "FAIL: ${hazards} deployed project(s) crossed the net8 shared-framework ceiling."
+    echo "These will build/test clean but fail startup on Azure."
+    echo "Roll back the package that pulled in the 10.x family (typically Azure.Identity)."
+    exit 1
+fi
+echo "OK: no shared-framework ceiling violations."

--- a/security-updates.sh
+++ b/security-updates.sh
@@ -30,8 +30,28 @@ DEPLOYED_PROJECTS=(
     src/BackendAccountService.ValidationData.Api
 )
 
-echo "==> dotnet outdated --version-lock Major --upgrade"
-dotnet outdated --version-lock Major --upgrade "$SLN"
+# Packages held back from `--upgrade` because the latest within-major
+# version pulls in transitives that cross the net8 ceiling. Each entry
+# needs a one-line reason; re-evaluate when migrating off net8.
+HOLD_BACK=(
+    Azure.Identity  # 1.21+ pulls Microsoft.Extensions.* 10.x via Azure.Core 1.53
+)
+
+EXCLUDE_FLAGS=()
+for pkg in "${HOLD_BACK[@]}"; do
+    EXCLUDE_FLAGS+=(--exclude "$pkg")
+done
+
+echo "==> dotnet outdated --version-lock Major --upgrade (excluding held-back packages)"
+dotnet outdated --version-lock Major --upgrade "${EXCLUDE_FLAGS[@]}" "$SLN"
+
+echo
+echo "==> dotnet build"
+dotnet build "$SLN"
+
+echo
+echo "==> dotnet test"
+dotnet test "$SLN" --no-build
 
 echo
 echo "==> Probing deployed projects for transitive framework-bundled assemblies above net8 ceiling"
@@ -51,8 +71,8 @@ done
 echo
 if [ "$hazards" -gt 0 ]; then
     echo "FAIL: ${hazards} deployed project(s) crossed the net8 shared-framework ceiling."
-    echo "These will build/test clean but fail startup on Azure."
-    echo "Roll back the package that pulled in the 10.x family (typically Azure.Identity)."
+    echo "Identify the package that pulled in the 10.x family, add it to HOLD_BACK,"
+    echo "revert the csproj changes with \`git restore -- 'src/**/*.csproj'\`, re-run."
     exit 1
 fi
-echo "OK: no shared-framework ceiling violations."
+echo "OK: upgrade applied, build + tests green, net8 ceiling intact."

--- a/src/BackendAccountService.Api.UnitTests/BackendAccountService.Api.UnitTests.csproj
+++ b/src/BackendAccountService.Api.UnitTests/BackendAccountService.Api.UnitTests.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Moq" Version="4.20.72" />
 	<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.Text.Json" Version="10.0.3" />
+    <PackageReference Include="System.Text.Json" Version="10.0.9" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
 	  
   </ItemGroup>

--- a/src/BackendAccountService.Api/BackendAccountService.Api.csproj
+++ b/src/BackendAccountService.Api/BackendAccountService.Api.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="MagicMapper" Version="14.0.1" />
-    <PackageReference Include="Azure.Identity" Version="1.21.0" />
+    <PackageReference Include="Azure.Identity" Version="1.17.1" />
     <PackageReference Include="FluentValidation" Version="12.1.1" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.1" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
@@ -29,7 +29,7 @@
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.28" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.9.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
-    <PackageReference Include="System.Text.Json" Version="10.0.3" />
+    <PackageReference Include="System.Text.Json" Version="8.0.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BackendAccountService.Core.UnitTests/BackendAccountService.Core.UnitTests.csproj
+++ b/src/BackendAccountService.Core.UnitTests/BackendAccountService.Core.UnitTests.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <PackageReference Include="AwesomeAssertions" Version="9.4.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.28" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
     <PackageReference Include="coverlet.msbuild" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -28,7 +28,7 @@
     </PackageReference>
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.Text.Json" Version="10.0.3" />
+    <PackageReference Include="System.Text.Json" Version="10.0.9" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 

--- a/src/BackendAccountService.Core/BackendAccountService.Core.csproj
+++ b/src/BackendAccountService.Core/BackendAccountService.Core.csproj
@@ -23,11 +23,11 @@
   
   <ItemGroup>
     <PackageReference Include="MagicMapper" Version="14.0.1" />
-    <PackageReference Include="Azure.Identity" Version="1.21.0" />
+    <PackageReference Include="Azure.Identity" Version="1.17.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.3.11" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.1" />
-    <PackageReference Include="System.Text.Json" Version="10.0.3" />
+    <PackageReference Include="System.Text.Json" Version="8.0.6" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/BackendAccountService.Data.IntegrationTests/BackendAccountService.Data.IntegrationTests.csproj
+++ b/src/BackendAccountService.Data.IntegrationTests/BackendAccountService.Data.IntegrationTests.csproj
@@ -32,7 +32,7 @@
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="System.Net.Http" Version="4.3.4" />
-        <PackageReference Include="System.Text.Json" Version="10.0.3" />
+        <PackageReference Include="System.Text.Json" Version="10.0.9" />
         <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
         <PackageReference Include="Testcontainers" Version="4.12.0" />
         <PackageReference Include="Testcontainers.MsSql" Version="4.12.0" />

--- a/src/BackendAccountService.Data.LaTestSeeder/BackendAccountService.Data.LaTestSeeder.csproj
+++ b/src/BackendAccountService.Data.LaTestSeeder/BackendAccountService.Data.LaTestSeeder.csproj
@@ -20,7 +20,7 @@
       <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
       <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
-      <PackageReference Include="System.Text.Json" Version="10.0.3" />
+      <PackageReference Include="System.Text.Json" Version="10.0.9" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/BackendAccountService.Data.UnitTests/BackendAccountService.Data.UnitTests.csproj
+++ b/src/BackendAccountService.Data.UnitTests/BackendAccountService.Data.UnitTests.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.11.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.11.1" />
-    <PackageReference Include="System.Text.Json" Version="10.0.3" />
+    <PackageReference Include="System.Text.Json" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BackendAccountService.Data/BackendAccountService.Data.csproj
+++ b/src/BackendAccountService.Data/BackendAccountService.Data.csproj
@@ -11,7 +11,7 @@
   </Target>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.21.0" />
+    <PackageReference Include="Azure.Identity" Version="1.17.1" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.28">
       <PrivateAssets>all</PrivateAssets>
@@ -25,7 +25,7 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.19.1" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.19.1" />
-    <PackageReference Include="System.Text.Json" Version="10.0.3" />
+    <PackageReference Include="System.Text.Json" Version="8.0.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BackendAccountService.ValidationData.Api.UnitTests/BackendAccountService.ValidationData.Api.UnitTests.csproj
+++ b/src/BackendAccountService.ValidationData.Api.UnitTests/BackendAccountService.ValidationData.Api.UnitTests.csproj
@@ -28,7 +28,7 @@
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="System.Net.Http" Version="4.3.4" />
-        <PackageReference Include="System.Text.Json" Version="10.0.3" />
+        <PackageReference Include="System.Text.Json" Version="10.0.9" />
         <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     </ItemGroup>
 

--- a/src/BackendAccountService.ValidationData.Api/BackendAccountService.ValidationData.Api.csproj
+++ b/src/BackendAccountService.ValidationData.Api/BackendAccountService.ValidationData.Api.csproj
@@ -4,13 +4,13 @@
         <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Azure.Identity" Version="1.21.0" />
+        <PackageReference Include="Azure.Identity" Version="1.17.1" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.3.11" />
         <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
         <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
         <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.6.0" />
         <PackageReference Include="System.Net.Http" Version="4.3.4" />
-        <PackageReference Include="System.Text.Json" Version="10.0.3" />
+        <PackageReference Include="System.Text.Json" Version="8.0.6" />
         <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     </ItemGroup>
     <ItemGroup>

--- a/src/BackendAccountService.sln
+++ b/src/BackendAccountService.sln
@@ -26,6 +26,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		../CODEOWNERS = ../CODEOWNERS
 		../Makefile = ../Makefile
 		../Directory.Build.props = ../Directory.Build.props
+		../security-updates.sh = ../security-updates.sh
 	EndProjectSection
 EndProject
 Project("{E53339B2-1760-4266-BCC7-CA923CBCF16C}") = "docker-compose", "docker-compose.dcproj", "{D7D9D14C-1C3F-41E5-B9E4-84683CF33786}"


### PR DESCRIPTION
The last update f18a8d447ad35531c5482e7f7fbe1f08387aa51e / PR #30 failed to run on azure as it pulled in some dotnet 10 libs, which works in CI build & test, but fails when deployed to azure.

This PR:

1. Adds a script for doing updates and checking it has not accidentally pulled in transitive dotnet 10 packages
2. Downgrades affected packages
3. Applies new dependency updates to latest minor version while avoiding any net10 

It would be better if CI would fail rather than only finding out when deployed but that seems less trivial. Suggestions welcome.

# Ticket

Supporting work for https://eaflood.atlassian.net/browse/AMCR-212